### PR TITLE
fix output of `snmp2_real_walk()` for php5.4

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -596,6 +596,8 @@ function snmptable($host, $community, $oid) {
     snmp_set_oid_numeric_print(TRUE);
     snmp_set_quick_print(TRUE);
     snmp_set_enum_print(TRUE);
+    snmp_set_valueretrieval(SNMP_VALUE_PLAIN );
+    snmp_set_oid_output_format(SNMP_OID_OUTPUT_NUMERIC);
 
     $retval = array();
     if(!$raw = snmp2_real_walk($host, $community, $oid)) {


### PR DESCRIPTION
the default output settings has changed for php5.4 and needs to be pinned to simple, numeric output explicitly now. Tested on php5.4 and php5.3.
