### PR TITLE
Prepend datacenter id to hostname for graphite export.

### DIFF
--- a/config.php.sample
+++ b/config.php.sample
@@ -34,6 +34,7 @@ $RRA_max     = "RRA:MAX:0.5:1:44640 RRA:MAX:0.5:60:8760";
 # $carbon_port = 2009;
 # $graphite_prefix = "network";
 # $graphite_metrics = array("inerrors","outdiscards");
+# $graphite_datacenter = "dc1";
 
 # Database connection parameters
 $mysql_host = "localhost";

--- a/poller_child.php
+++ b/poller_child.php
@@ -27,7 +27,7 @@ $pollsnmpcomm = $pollhosts[$pollhost]["snmpcommunity"];
 $pollgraphs = $pollhosts[$pollhost]["graphtypes"];
 
 # Connect carbon.
-if (isset($carbon_host,$carbon_port,$graphite_prefix,$graphite_metrics)) {
+if (isset($carbon_host,$carbon_port,$graphite_prefix,$graphite_metrics,$graphite_datacenter)) {
     $carbon = fsockopen($carbon_host, $carbon_port, $errno, $errstr, 5);
     if (!$carbon) {
         logline("{$pollprettyhost} - Connect to carbon failed.", 0, $verbose);
@@ -86,7 +86,7 @@ foreach($ifEntry as $intid => $thisint) {
         # Send data to carbon.
         if ($carbon) {
             foreach($graphite_metrics as $metric) {
-                fwrite($carbon, "{$graphite_prefix}.{$pollprettyhost}.{$thisint['name']}.{$metric} {$thisint[$metric]} {$timestamp}\n");
+                fwrite($carbon, "{$graphite_prefix}.{$graphite_datacenter}-{$pollprettyhost}.{$thisint['name']}.{$metric} {$thisint[$metric]} {$timestamp}\n");
             }
         }
        


### PR DESCRIPTION
Resolves the hostname overlap when sending data from multiple fitb instances to a single graphite instance.